### PR TITLE
fix: fall back to $0 when BASH_SOURCE[0] is empty (zsh compat)

### DIFF
--- a/cmd.sh
+++ b/cmd.sh
@@ -14,7 +14,7 @@ get_script_dir () {
 export -f get_script_dir
 
 
-SCRIPT_DIR=$(get_script_dir "${BASH_SOURCE[0]}")
+SCRIPT_DIR=$(get_script_dir "${BASH_SOURCE[0]:-$0}")
 source "${SCRIPT_DIR}/_shared.sh"
 
 


### PR DESCRIPTION
## Summary

- `BASH_SOURCE[0]` is bash-only and is unset/empty in zsh
- When zsh sources `cmd.sh` (via `~/.bash.d/*` in `.zshrc`), `get_script_dir ""` resolves to CWD instead of the script's directory, producing a path like `/path/to/cwd/_shared.sh` that doesn't exist
- `${BASH_SOURCE[0]:-$0}` fixes this: in zsh, `$0` within a sourced file is the script path

## Test plan

- [ ] Open a new zsh terminal — no `_shared.sh` error on startup
- [ ] `ciao list` works in zsh
- [ ] `ciao list` still works in bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)