### PR TITLE
fix: remove export -f get_script_dir to silence zsh output

### DIFF
--- a/cmd.sh
+++ b/cmd.sh
@@ -11,7 +11,6 @@ get_script_dir () {
     done
     echo "$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 }
-export -f get_script_dir
 
 
 SCRIPT_DIR=$(get_script_dir "${BASH_SOURCE[0]:-$0}")


### PR DESCRIPTION
## Summary

- `get_script_dir` is only used within `cmd.sh` itself — there's no reason to export it
- `export -f` causes zsh to print the function definition verbatim on every new terminal session when it inherits exported bash functions from the environment

## Test plan

- [ ] Open a new terminal — `get_script_dir` function body no longer printed on startup
- [ ] `ciao list` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)